### PR TITLE
Fixed deprecated error for cakephp 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.4",
-    "cakephp/cakephp": "^4.0.0"
+    "cakephp/cakephp": "^4.2.0"
   },
   "require-dev": {
     "robmorgan/phinx": "^0.12",

--- a/src/Model/Behavior/LocatableBehavior.php
+++ b/src/Model/Behavior/LocatableBehavior.php
@@ -43,7 +43,7 @@ class LocatableBehavior extends Behavior
     public function initialize(array $config): void
     {
         if (empty($this->getConfig('modelClass'))) {
-            $this->setConfig('modelClass', $this->getTable()->getAlias());
+            $this->setConfig('modelClass', $this->table()->getAlias());
         }
 
         $this->_table->hasOne('Coordinates')


### PR DESCRIPTION
Edited the line 46 at src\Model\Behavior\LocatableBehavior.php
Updated the cakephp version to 4.2 or greater composer.json 